### PR TITLE
Fix not initialized property

### DIFF
--- a/src/WebService/CourseManagement/CourseManagement.wsdl
+++ b/src/WebService/CourseManagement/CourseManagement.wsdl
@@ -479,6 +479,7 @@
           <s:element minOccurs="0" maxOccurs="1" name="ParentID" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="ObjectType" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="OriginalFileName" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="MediaFileID" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="FieldsXml" type="s:string" />
         </s:sequence>
       </s:complexType>

--- a/src/WebService/CourseManagement/Type/Reference.php
+++ b/src/WebService/CourseManagement/Type/Reference.php
@@ -70,6 +70,9 @@ class Reference
     private ?string $OriginalFileName;
 
     
+    private ?string $MediaFileID;
+
+    
     private ?string $FieldsXml;
 
     
@@ -372,6 +375,21 @@ class Reference
     {
         $new = clone $this;
         $new->OriginalFileName = $OriginalFileName;
+
+        return $new;
+    }
+
+    
+    public function getMediaFileID(): ?string
+    {
+        return $this->MediaFileID;
+    }
+
+    
+    public function withMediaFileID(?string $MediaFileID): static
+    {
+        $new = clone $this;
+        $new->MediaFileID = $MediaFileID;
 
         return $new;
     }

--- a/src/WebService/LearnerManagement/LearnerManagement.wsdl
+++ b/src/WebService/LearnerManagement/LearnerManagement.wsdl
@@ -897,6 +897,7 @@
           <s:element minOccurs="0" maxOccurs="1" name="ParentID" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="ObjectType" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="OriginalFileName" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="MediaFileID" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="FieldsXml" type="s:string" />
         </s:sequence>
       </s:complexType>

--- a/src/WebService/LearnerManagement/LearnerManagementSoapClientConfig.php
+++ b/src/WebService/LearnerManagement/LearnerManagementSoapClientConfig.php
@@ -81,7 +81,7 @@ return Config::create()
             '/^ServiceUser$/'
         )
     )
-    // Properties Title,ScreenName, Language in ServiceUser class are optional with default value
+    // Properties Title,ScreenName, Language in ServiceUser and ServiceSupervisor in ArrayOfServiceSupervisor class are optional with default value
     ->addRule(
         new Rules\TypenameMatchesRule(
             new Rules\PropertynameMatchesRule(
@@ -89,9 +89,9 @@ return Config::create()
                     (new Assembler\PropertyAssemblerOptions())
                         ->withOptionalValue()
                 )),
-                '/^(Title|ScreenName|Language)$/'
+                '/^(Title|ScreenName|Language|ServiceSupervisor)$/'
             ),
-            '/ServiceUser$/'
+            '/^(ServiceUser|ArrayOfServiceSupervisor)$/'
         )
     )
     /**

--- a/src/WebService/LearnerManagement/Type/ArrayOfServiceSupervisor.php
+++ b/src/WebService/LearnerManagement/Type/ArrayOfServiceSupervisor.php
@@ -9,7 +9,7 @@ class ArrayOfServiceSupervisor
     /**
      * @var null | array<int<0,max>, \Lingoda\ThinkingcapBundle\WebService\LearnerManagement\Type\ServiceSupervisor>
      */
-    private ?array $ServiceSupervisor;
+    private ?array $ServiceSupervisor = null;
 
     /**
      * @return null | array<int<0,max>, \Lingoda\ThinkingcapBundle\WebService\LearnerManagement\Type\ServiceSupervisor>

--- a/src/WebService/LearnerManagement/Type/Reference.php
+++ b/src/WebService/LearnerManagement/Type/Reference.php
@@ -70,6 +70,9 @@ class Reference
     private ?string $OriginalFileName;
 
     
+    private ?string $MediaFileID;
+
+    
     private ?string $FieldsXml;
 
     
@@ -372,6 +375,21 @@ class Reference
     {
         $new = clone $this;
         $new->OriginalFileName = $OriginalFileName;
+
+        return $new;
+    }
+
+    
+    public function getMediaFileID(): ?string
+    {
+        return $this->MediaFileID;
+    }
+
+    
+    public function withMediaFileID(?string $MediaFileID): static
+    {
+        $new = clone $this;
+        $new->MediaFileID = $MediaFileID;
 
         return $new;
     }


### PR DESCRIPTION
Fixed `$ServiceSupervisor must not be accessed before initialization` during Sync Supervisors